### PR TITLE
Added YiiRequestSimplified to enable system to resolve PATH_INFO properly

### DIFF
--- a/custom/classes/YiiRequestSimplified.inc.php
+++ b/custom/classes/YiiRequestSimplified.inc.php
@@ -1,0 +1,182 @@
+<?php
+
+/**
+ * @file custom/classes/YiiRequestSimplified.inc.php
+ *
+ * All methods of this class were stolen from Request class
+ * of Yii2 framework.
+ * This workaround should help with path info determination.
+ */
+
+class YiiRequestSimplified
+{
+    /**
+     * Returns the relative URL for the application.
+     * This is similar to [[scriptUrl]] except that it does not include the script file name,
+     * and the ending slashes are removed.
+     * @return string the relative URL for the application
+     * @see setScriptUrl()
+     */
+    public function getBaseUrl()
+    {
+        return rtrim(dirname($this->getScriptUrl()), '\\/');
+    }
+
+    private $_scriptUrl;
+
+    /**
+     * Returns the relative URL of the entry script.
+     * The implementation of this method referenced Zend_Controller_Request_Http in Zend Framework.
+     * @return string the relative URL of the entry script.
+     * @throws Exception if unable to determine the entry script URL
+     */
+    public function getScriptUrl()
+    {
+        if ($this->_scriptUrl === null) {
+            $scriptFile = $this->getScriptFile();
+            $scriptName = basename($scriptFile);
+            if (isset($_SERVER['SCRIPT_NAME']) && basename($_SERVER['SCRIPT_NAME']) === $scriptName) {
+                $this->_scriptUrl = $_SERVER['SCRIPT_NAME'];
+            } elseif (isset($_SERVER['PHP_SELF']) && basename($_SERVER['PHP_SELF']) === $scriptName) {
+                $this->_scriptUrl = $_SERVER['PHP_SELF'];
+            } elseif (isset($_SERVER['ORIG_SCRIPT_NAME']) && basename($_SERVER['ORIG_SCRIPT_NAME']) === $scriptName) {
+                $this->_scriptUrl = $_SERVER['ORIG_SCRIPT_NAME'];
+            } elseif (isset($_SERVER['PHP_SELF']) && ($pos = strpos($_SERVER['PHP_SELF'], '/' . $scriptName)) !== false) {
+                $this->_scriptUrl = substr($_SERVER['SCRIPT_NAME'], 0, $pos) . '/' . $scriptName;
+            } elseif (!empty($_SERVER['DOCUMENT_ROOT']) && strpos($scriptFile, $_SERVER['DOCUMENT_ROOT']) === 0) {
+                $this->_scriptUrl = str_replace('\\', '/', str_replace($_SERVER['DOCUMENT_ROOT'], '', $scriptFile));
+            } else {
+                throw new Exception('Unable to determine the entry script URL.');
+            }
+        }
+
+        return $this->_scriptUrl;
+    }
+
+    private $_scriptFile;
+
+    /**
+     * Returns the entry script file path.
+     * The default implementation will simply return `$_SERVER['SCRIPT_FILENAME']`.
+     * @return string the entry script file path
+     * @throws Exception
+     */
+    public function getScriptFile()
+    {
+        if (isset($this->_scriptFile)) {
+            return $this->_scriptFile;
+        } elseif (isset($_SERVER['SCRIPT_FILENAME'])) {
+            return $_SERVER['SCRIPT_FILENAME'];
+        } else {
+            throw new Exception('Unable to determine the entry script file path.');
+        }
+    }
+
+
+    /**
+     * Returns the path info of the currently requested URL.
+     * A path info refers to the part that is after the entry script and before the question mark (query string).
+     * The starting and ending slashes are both removed.
+     * @return string part of the request URL that is after the entry script and before the question mark.
+     * Note, the returned path info is already URL-decoded.
+     * @throws Exception if the path info cannot be determined due to unexpected server configuration
+     */
+    public function getPathInfo()
+    {
+        return $this->resolvePathInfo();
+    }
+
+    /**
+     * Resolves the path info part of the currently requested URL.
+     * A path info refers to the part that is after the entry script and before the question mark (query string).
+     * The starting slashes are both removed (ending slashes will be kept).
+     * @return string part of the request URL that is after the entry script and before the question mark.
+     * Note, the returned path info is decoded.
+     * @throws Exception if the path info cannot be determined due to unexpected server configuration
+     */
+    protected function resolvePathInfo()
+    {
+        $pathInfo = $this->getUrl();
+
+        if (($pos = strpos($pathInfo, '?')) !== false) {
+            $pathInfo = substr($pathInfo, 0, $pos);
+        }
+
+        $pathInfo = urldecode($pathInfo);
+
+        // try to encode in UTF8 if not so
+        // http://w3.org/International/questions/qa-forms-utf-8.html
+        if (!preg_match('%^(?:
+            [\x09\x0A\x0D\x20-\x7E]              # ASCII
+            | [\xC2-\xDF][\x80-\xBF]             # non-overlong 2-byte
+            | \xE0[\xA0-\xBF][\x80-\xBF]         # excluding overlongs
+            | [\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}  # straight 3-byte
+            | \xED[\x80-\x9F][\x80-\xBF]         # excluding surrogates
+            | \xF0[\x90-\xBF][\x80-\xBF]{2}      # planes 1-3
+            | [\xF1-\xF3][\x80-\xBF]{3}          # planes 4-15
+            | \xF4[\x80-\x8F][\x80-\xBF]{2}      # plane 16
+            )*$%xs', $pathInfo)
+        ) {
+            $pathInfo = utf8_encode($pathInfo);
+        }
+
+        $scriptUrl = $this->getScriptUrl();
+        $baseUrl = $this->getBaseUrl();
+        if (strpos($pathInfo, $scriptUrl) === 0) {
+            $pathInfo = substr($pathInfo, strlen($scriptUrl));
+        } elseif ($baseUrl === '' || strpos($pathInfo, $baseUrl) === 0) {
+            $pathInfo = substr($pathInfo, strlen($baseUrl));
+        } elseif (isset($_SERVER['PHP_SELF']) && strpos($_SERVER['PHP_SELF'], $scriptUrl) === 0) {
+            $pathInfo = substr($_SERVER['PHP_SELF'], strlen($scriptUrl));
+        } else {
+            throw new Exception('Unable to determine the path info of the current request.');
+        }
+
+        if (substr($pathInfo, 0, 1) === '/') {
+            $pathInfo = substr($pathInfo, 1);
+        }
+
+        return (string) $pathInfo;
+    }
+
+    /**
+     * Returns the currently requested relative URL.
+     * This refers to the portion of the URL that is after the [[hostInfo]] part.
+     * It includes the [[queryString]] part if any.
+     * @return string the currently requested relative URL. Note that the URI returned is URL-encoded.
+     * @throws Exception if the URL cannot be determined due to unusual server configuration
+     */
+    public function getUrl()
+    {
+        return $this->resolveRequestUri();
+    }
+
+    /**
+     * Resolves the request URI portion for the currently requested URL.
+     * This refers to the portion that is after the [[hostInfo]] part. It includes the [[queryString]] part if any.
+     * The implementation of this method referenced Zend_Controller_Request_Http in Zend Framework.
+     * @return string|boolean the request URI portion for the currently requested URL.
+     * Note that the URI returned is URL-encoded.
+     * @throws Exception if the request URI cannot be determined due to unusual server configuration
+     */
+    protected function resolveRequestUri()
+    {
+        if (isset($_SERVER['HTTP_X_REWRITE_URL'])) { // IIS
+            $requestUri = $_SERVER['HTTP_X_REWRITE_URL'];
+        } elseif (isset($_SERVER['REQUEST_URI'])) {
+            $requestUri = $_SERVER['REQUEST_URI'];
+            if ($requestUri !== '' && $requestUri[0] !== '/') {
+                $requestUri = preg_replace('/^(http|https):\/\/[^\/]+/i', '', $requestUri);
+            }
+        } elseif (isset($_SERVER['ORIG_PATH_INFO'])) { // IIS 5.0 CGI
+            $requestUri = $_SERVER['ORIG_PATH_INFO'];
+            if (!empty($_SERVER['QUERY_STRING'])) {
+                $requestUri .= '?' . $_SERVER['QUERY_STRING'];
+            }
+        } else {
+            throw new Exception('Unable to determine the request URI.');
+        }
+
+        return $requestUri;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -59,6 +59,11 @@
 define('INDEX_FILE_LOCATION', __FILE__);
 require('./lib/pkp/includes/bootstrap.inc.php');
 
+import('custom.classes.YiiRequestSimplified');
+$yii_request = new YiiRequestSimplified();
+$_SERVER['PATH_INFO'] = $yii_request->getPathInfo();
+unset($yii_request);
+
 // Serve the request
 $application =& PKPApplication::getApplication();
 $application->execute();


### PR DESCRIPTION
For #7.
This simplifies config of mod_rewrite. Now it's possible to use most common config (anyway I think this is the most common after googling).

```
RewriteEngine on
RewriteCond %{REQUEST_FILENAME} !-d
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule . index.php [L]
```

I've tested on my local environment, seems to be work fine. Also I've set **restful_urls = On** in config to exclude **index.php** from generated urls.
